### PR TITLE
Update sgc.csv

### DIFF
--- a/metrics/sgc.csv
+++ b/metrics/sgc.csv
@@ -2,6 +2,7 @@ Name,Labels,Description,Child
 wmo_wis2_sgc_cache_delay_seconds,globalcache|centre_id|report_by,Delay between origin and cache message,-
 wmo_wis2_sgc_messages_cached_total,globalcache|centre_id|report_by,Number of data files cached for centre_id,-
 wmo_wis2_sgc_messages_cached_delay_total,globalcache|centre_id|delay|report_by,Number of data files cached for centre_id within defined delay (120s 300s 600s),-
+wmo_wis2_sgc_messages_duplicates_total,centre_id|report_by,Number of messages with identical data_id and no "rel=update",-
 wmo_wis2_sgc_messages_published_total,centre_id|report_by,Number of cacheable data files published,-
 wmo_wis2_sgc_messages_missed_total,globalcache|centre_id|report_by,Number of cacheable data not in global cache,-
 wmo_wis2_sgc_messages_missed_all_total,centre_id|report_by,Number of cacheable data not in any cache,-


### PR DESCRIPTION
I suggest adding a metric to count the number of messages with the same data_id, a more recent pubtime and missing the rel=update. Therefore, the new (?) data announced will not be cached as Global Cache will consider this as a duplicate data_id.