### PR TITLE
update GDC metrics and alerts

### DIFF
--- a/alerts/gdc.yml
+++ b/alerts/gdc.yml
@@ -1,20 +1,6 @@
 groups:
   - name: GlobalDiscoveryCatalogue
     rules:
-      - alert: Connection_lost_from_global_broker
-        expr: group by (centre_id) (wmo_wis2_gdc_connected_flag{centre_id =~ ".*global-broker"} == 0) > 0
-        for: 10m
-        labels:
-          severity: critical 
-        annotations:
-          summary: Connection to a Global Broker is lost
-      - alert: Download_errors_from_global_cache
-        expr: group by (centre_id) (delta (wmo_wis2_gdc_downloaded_errors_total{centre_id =~ ".*global-cache"}[1h]) > 0) > 0
-        for: 1h
-        labels:
-          severity: warning
-        annotations:
-          summary: Download errors from Global Cache in the last hour
       - alert: Metadata_archive_older_than_24_hours
         expr: time() - wmo_wis2_gc_last_metadata_timestamp_seconds{centre_id =~ ".*global-discovery-catalogue"} > 86400
         labels:

--- a/metrics/gdc.csv
+++ b/metrics/gdc.csv
@@ -1,13 +1,7 @@
 Name,Labels,Description,Child,Initialize
-wmo_wis2_gdc_passed_total,centre_id|report_by,Number of metadata records passed validation,-,true
-wmo_wis2_gdc_failed_total,centre_id|report_by,Number of metadata records failed validation,-,true
 wmo_wis2_gdc_core_total,centre_id|report_by,Number of core metadata records,-,true
 wmo_wis2_gdc_recommended_total,centre_id|report_by,Number of recommended metadata records,-,true
-wmo_wis2_gdc_kpi_percentage_total,metadata_id|centre_id|report_by,KPI percentage for a single metadata record (metadata_id equals WCMP2 id),-,false
+wmo_wis2_gdc_earth_system_discipline_total,earth_system_discipline|centre_id|report_by,Number of metadata records for an Earth system discipline,-,false
+wmo_wis2_gdc_kpi_percentage_total,metadata_id|centre_id|report_by,KPI percentage for a single metadata record (metadata_id = WCMP2 id),-,false
 wmo_wis2_gdc_kpi_percentage_average,centre_id|report_by,Average KPI percentage,-,false
 wmo_wis2_gdc_kpi_percentage_over80_total,centre_id|report_by,Number of metadata records with KPI percentage over 80,-,false
-wmo_wis2_gdc_search_total,centre_id|report_by,Number of search requests (during last monitoring period),-,false
-wmo_wis2_gdc_search_terms,top|centre_id|report_by,Most popular search terms (e.g. top=1 to top=5),-,false
-wmo_wis2_gdc_connected_flag,centre_id|report_by,Connection status from GDC to to centre,-,false
-wmo_wis2_gdc_api_status,centre_id,Status of GDC API,-,false
-wmo_wis2_gdc_downloaded_errors_total,centre_id|report_by,Number of metadata download errors,-,false


### PR DESCRIPTION
This PR updates GDC metrics and alerts definitions.  The driving workflow is being able to run metrics on an existing GDC repository (even as an offline/backend process) as a permanent repository (i.e. we do not need to track metrics of realtime metadata publication).

In support of https://github.com/wmo-im/et-w2it/issues/36 cc @golfvert @Amienshxq @kaiwirt @el4ren