### PR TITLE
SCGC metrics: delay -> delay_threshold

### DIFF
--- a/metrics/scgc.csv
+++ b/metrics/scgc.csv
@@ -1,7 +1,7 @@
 Name,Labels,Description,Child
 wmo_wis2_scgc_cache_delay_seconds,global_cache|centre_id|report_by,Delay between origin and cache message,-
 wmo_wis2_scgc_messages_cached_total,global_cache|centre_id|report_by,Number of data files cached for centre_id,-
-wmo_wis2_scgc_messages_cached_delay_total,global_cache|centre_id|delay|report_by,Number of data files cached for centre_id within defined delay (120s 300s 600s),-
+wmo_wis2_scgc_messages_cached_delay_total,global_cache|centre_id|delay_threshold|report_by,Number of data files cached for centre_id within defined delay threshold (120s 300s 600s),-
 wmo_wis2_scgc_messages_duplicates_total,centre_id|report_by,Number of messages with identical data_id and no rel=update,-
 wmo_wis2_scgc_messages_published_total,centre_id|report_by,Number of cacheable data files published,-
 wmo_wis2_scgc_messages_missed_total,global_cache|centre_id|report_by,Number of cacheable data not in global cache,-


### PR DESCRIPTION
Following discussion by ET-W2IT (24-Nov-2025), request to amend the "delay" label to "delay threshold", thereby avoiding confusion. The metric label is used to group counts into buckets - rather than being the _actual_ delay for the message.