### PR TITLE
Clarify description for gc_downloaded_total metric

### DIFF
--- a/metrics/gc.csv
+++ b/metrics/gc.csv
@@ -1,5 +1,5 @@
 Name,Labels,Description,Child,Initialize
-wmo_wis2_gc_downloaded_total,centre_id|report_by,Number of data items downloaded to Global Cache,-,false
+wmo_wis2_gc_downloaded_total,centre_id|report_by,Number of data items downloaded to Global Cache (not incremented when data items are retrieved from inline content),-,false
 wmo_wis2_gc_downloaded_errors_total,centre_id|report_by,Number of download errors for Global Cache data,-,false
 wmo_wis2_gc_last_download_timestamp_seconds,centre_id|report_by,Timestamp of last succesful download,-,false
 wmo_wis2_gc_integrity_failed_total,centre_id|report_by,Number of messages for which the integrity check failed,-,false


### PR DESCRIPTION
As discussed in ET-WISOP meeting 11-JUN-2026, Brasilia.

Updated description for wmo_wis2_gc_downloaded_total to clarify that it is not incremented when data items are retrieved from inline content.